### PR TITLE
Avoid broken action URL in text notification mail

### DIFF
--- a/Resources/views/Email/zurb_2/notification/body.txt.twig
+++ b/Resources/views/Email/zurb_2/notification/body.txt.twig
@@ -8,7 +8,7 @@
 
 {% block action %}
 {% if action_url %}
-{{ action_url }}: {{ action_text }}
+{{ action_text }}: {{ action_url }}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Some mail clients make URLs clickable automatically which leads to broken URLs due to the appended ":" (colon)

Fix this by moving the action text before the action URL.