### PR TITLE
Allow to set parent div checkbox class via {'row_class': 'foo'}

### DIFF
--- a/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -211,7 +211,7 @@
 {%- block checkbox_widget -%}
     {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {%- set row_class = 'form-check' -%}
+    {%- set row_class = row_class|default('form-check') -%}
     {%- if 'checkbox-inline' in parent_label_class %}
         {% set row_class = row_class ~ ' form-check-inline' %}
     {% endif -%}


### PR DESCRIPTION
We can't set parent div class at the moment. This PR allow us to do this:
```twig
{{ form_widget(form.agreeTerms, {'row_class': 'some custom classes'}) }}
```
result
```htm
<div class="some custom classes">
    <input type="checkbox" ...>
    <label ...>
</div>
```
This PR can be used with v6+ too.